### PR TITLE
fix examples

### DIFF
--- a/examples/pi_calculator_functional/calculate_pi.py
+++ b/examples/pi_calculator_functional/calculate_pi.py
@@ -133,7 +133,7 @@ def get_threshold(significant_digits):
     threshold: float
         The corresponding threshold.
     """
-    return 1 / (10 ** (significant_digits + 2))
+    return 1 / (10 ** (significant_digits + 1))
 
 
 def is_converged(threshold, history):

--- a/examples/pi_calculator_oop/pi_calculator.py
+++ b/examples/pi_calculator_oop/pi_calculator.py
@@ -47,7 +47,7 @@ class PiCalculator:
         significant_digits: int
             Number of significant digits to use to set the convergence threshold.
         """
-        threshold = 1 / 10**(self.significant_digits + 2)
+        threshold = 1 / 10**(self.significant_digits + 1)
         if len(self._history) < 100:
             return False
         return np.ptp(self._history[-100:]) < threshold

--- a/examples/pi_calculator_procedural/calculate_pi.py
+++ b/examples/pi_calculator_procedural/calculate_pi.py
@@ -26,7 +26,7 @@ if len(sys.argv) > 3:
 #        The number of darts thrown at one time, for which an updated calculation is made.
 
 ### Setup ###
-threshold = 1 / (10 ** N_SIG_DIGS + 2)
+threshold = 1 / (10 ** N_SIG_DIGS + 1)
 
 history = list()
 n_darts_thrown = 0


### PR DESCRIPTION
1. Fix some code issues with the procedural version (this is why I need tests 😂 )

2. Remove the recursion step from the functional version to avoid OOM errors

3. ~Up the threshold constraint, and simplify the comparison logic to help offset the resulting slowdown.~ The guesses after each scoring are highly correlated, so it was too likely for the guesses to all spuriously center around the wrong value within a threshold that was only 1/10 of the requested significant digit. This still happens, but by experiment is only ~1/10th as likely. EDIT: this was way too slow.